### PR TITLE
allow database url in place of individual fields

### DIFF
--- a/sample_config.json
+++ b/sample_config.json
@@ -1,4 +1,5 @@
 {
+  "url": null,
   "host": "localhost",
   "user": "test",
   "port": "5432",

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -119,6 +119,9 @@ class DbSync:
         self.rejected_count = 0
 
     def open_connection(self):
+        if self.connection_config['url']:
+            return psycopg2.connect(self.connection_config['url'])
+
         conn_string = "host='{}' dbname='{}' user='{}' password='{}' port='{}'".format(
             self.connection_config['host'],
             self.connection_config['dbname'],

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -119,7 +119,7 @@ class DbSync:
         self.rejected_count = 0
 
     def open_connection(self):
-        if self.connection_config['url']:
+        if 'url' in self.connection_config:
             return psycopg2.connect(self.connection_config['url'])
 
         conn_string = "host='{}' dbname='{}' user='{}' password='{}' port='{}'".format(

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -119,8 +119,12 @@ class DbSync:
         self.rejected_count = 0
 
     def open_connection(self):
-        if 'url' in self.connection_config:
-            return psycopg2.connect(self.connection_config['url'])
+        try:
+            url = self.connection_config['url']
+            if url:
+                return psycopg2.connect(url)
+        except KeyError:
+            pass
 
         conn_string = "host='{}' dbname='{}' user='{}' password='{}' port='{}'".format(
             self.connection_config['host'],


### PR DESCRIPTION
Our hosting exposes database connections as urls instead of separate user/host/port/dbname environment variables. If configuration option `url` is provided, it will use that to connect to the database instead of `host`, `dbname`, etc.