### PR TITLE
Set decimal precision

### DIFF
--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -14,12 +14,17 @@ from tempfile import NamedTemporaryFile
 
 import pkg_resources
 from jsonschema import Draft4Validator, FormatChecker
+import decimal
 from decimal import Decimal
 import singer
 from target_postgres.db_sync import DbSync
 
 logger = singer.get_logger()
 
+# This value comes from the precision definition of
+# Postgres numeric/decimal types:
+# https://www.postgresql.org/docs/9.1/datatype-numeric.html
+decimal.getcontext().prec = 147455
 
 def float_to_decimal(value):
     '''Walk the given data structure and turn all instances of float into


### PR DESCRIPTION
The following is an example schema output by `tap-postgres` for a numeric column:

```
{"type":"SCHEMA","stream":"foobar","schema":{"type":"object","properties":{"id":{"type":["integer"],"minimum":-2147483648,"maximum":2147483647},"sample_numeric":{"type":["null","number"],"exclusiveMaximum":true,"maximum":100000000000000000000000000000000000000000000000000000000000000,"multipleOf":1E-38,"exclusiveMinimum":true,"minimum":-100000000000000000000000000000000000000000000000000000000000000}}},"key_properties":["id"],"bookmark_properties":[]}
{"type":"RECORD","stream":"foobar","record":{"id":1,"sample_numeric":0.000913808181253534},"version":1596488217992,"time_extracted":"2020-08-03T20:56:57.992931Z"}
```

This results in the following error when validating the data against the JSON Schema:

```
  File "/Users/cjk/fixd/meltano/.meltano/loaders/target-postgres/venv/bin/target-postgres", line 11, in <module>
    load_entry_point('target-postgres===meltano.1.1.6', 'console_scripts', 'target-postgres')()
  File "/Users/cjk/fixd/meltano/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/target_postgres/__init__.py", line 151, in main
    state = persist_lines(config, input)
  File "/Users/cjk/fixd/meltano/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/target_postgres/__init__.py", line 80, in persist_lines
    validators[stream].validate(float_to_decimal(o['record']))
  File "/Users/cjk/fixd/meltano/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/jsonschema/validators.py", line 129, in validate
    for error in self.iter_errors(*args, **kwargs):
  File "/Users/cjk/fixd/meltano/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/jsonschema/validators.py", line 105, in iter_errors
    for error in errors:
  File "/Users/cjk/fixd/meltano/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/jsonschema/_validators.py", line 306, in properties_draft4
    schema_path=property,
  File "/Users/cjk/fixd/meltano/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/jsonschema/validators.py", line 121, in descend
    for error in self.iter_errors(instance, schema):
  File "/Users/cjk/fixd/meltano/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/jsonschema/validators.py", line 105, in iter_errors
    for error in errors:
  File "/Users/cjk/fixd/meltano/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/jsonschema/_validators.py", line 129, in multipleOf
    failed = instance % dB
decimal.InvalidOperation: [<class 'decimal.DivisionImpossible'>]
```

The `decimal.DivisionImpossible` error is [this issue](https://stackoverflow.com/questions/42868278/decimal-invalidoperation-divisionimpossible-for-very-large-numbers), caused by running out of the default decimal precision when trying to run `Decimal('0.000666259154868687') % Decimal('1E-38')` (for verifying `multipleOf`).

`tap-postgres` is using `multipleOf` to effectively [report the scale of the column](https://github.com/singer-io/tap-postgres/blob/e990e88e4c41720e982c49f77dee8fc6149124de/tap_postgres/db.py#L192). 

This PR walks all new JSON Schemas, and uses `minimum`, `maximum`, and `multipleOf` to try and predict the required precision and [update the decimal context](https://docs.python.org/3/library/decimal.html) appropriately.