### PR TITLE
fix non-null falsey values

### DIFF
--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -189,7 +189,7 @@ class DbSync:
         flatten = flatten_record(record)
         return ','.join(
             [
-                json.dumps(flatten[name]) if name in flatten and flatten[name] else ''
+                json.dumps(flatten[name]) if name in flatten and flatten[name] != None else ''
                 for name in self.flatten_schema
             ]
         )

--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -189,7 +189,7 @@ class DbSync:
         flatten = flatten_record(record)
         return ','.join(
             [
-                json.dumps(flatten[name]) if name in flatten and flatten[name] != None else ''
+                json.dumps(flatten[name]) if name in flatten and flatten[name] is not None else ''
                 for name in self.flatten_schema
             ]
         )


### PR DESCRIPTION
The CSV conversion replaces falsey values, such as integers of value zero, with empty string. For non-null columns, this results in a not-null constraint violation.

```
target-postgres       | INFO Loading 6118 rows into 'sender_statistics'
target-postgres       | INFO COPY sender_statistics_temp ("category", "cc", "count", "disp", "dkim_d", "dkim_policy", "dkim_res", "end_date", "h_from", "ip", "ptr", "ptr_org", "reason", "report_date", "report_id", "row_id", "slug", "spf_d", "spf_policy", "spf_res") FROM STDIN WITH (FORMAT CSV, ESCAPE '\')
target-postgres       | Traceback (most recent call last):
target-postgres       |   File "/Users/cjk/fixd/data42/.meltano/loaders/target-postgres/venv/bin/target-postgres", line 8, in <module>
target-postgres       |     sys.exit(main())
target-postgres       |   File "/Users/cjk/fixd/data42/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/target_postgres/__init__.py", line 188, in main
target-postgres       |     state = persist_lines(config, input)
target-postgres       |   File "/Users/cjk/fixd/data42/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/target_postgres/__init__.py", line 163, in persist_lines
target-postgres       |     stream_to_sync[stream_name].load_csv(csv_files_to_load[stream_name], count)
target-postgres       |   File "/Users/cjk/fixd/data42/.meltano/loaders/target-postgres/venv/lib/python3.7/site-packages/target_postgres/db_sync.py", line 214, in load_csv
target-postgres       |     file
target-postgres       | psycopg2.errors.NotNullViolation: null value in column "row_id" of relation "sender_statistics_temp" violates not-null constraint
```

This fix does an explicit check for `None` instead.